### PR TITLE
feat: Add devcontainer setup and contributing docs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/devcontainers/base:jammy
+
+ARG PIXI_VERSION=v0.53.0
+
+RUN curl -L -o /usr/local/bin/pixi -fsSL --compressed "https://github.com/prefix-dev/pixi/releases/download/${PIXI_VERSION}/pixi-$(uname -m)-unknown-linux-musl" \
+    && chmod +x /usr/local/bin/pixi \
+    && pixi info
+
+# set some user and workdir settings to work nicely with vscode
+ENV VSCODE_HOME=/home/vscode \
+    VSCODE_USER=vscode \
+    SHELL=/bin/bash
+USER ${VSCODE_USER}
+WORKDIR ${VSCODE_HOME}
+
+RUN echo 'eval "$(pixi completion -s bash)"' >> ${VSCODE_HOME}/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+    "name": "default-workspace",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "workbench.editorAssociations": {
+                    "*.md": "vscode.markdown.preview.editor"
+                }
+            },
+            "extensions": [
+                "ms-toolsai.jupyter",
+                "ms-python.python",
+                "charliermarsh.ruff",
+                "tamasfe.even-better-toml",
+                "jjjermiah.pixi-vscode"
+            ]
+        }
+    },
+    "features": {},
+    "mounts": [
+        "source=${localWorkspaceFolderBasename}-pixi,target=${containerWorkspaceFolder}/.pixi,type=volume"
+    ],
+    "onCreateCommand": ".devcontainer/onCreate.sh",
+    "updateContentCommand": ".devcontainer/updateContent.sh",
+    "hostRequirements": {
+        "cpus": 4,
+        "memory": "16gb",
+        "storage": "32gb"
+    }
+}

--- a/.devcontainer/onCreate.sh
+++ b/.devcontainer/onCreate.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# For writing commands that will be executed after the container is created
+set -e
+
+sudo chown vscode .pixi
+pixi install --all
+pixi shell-hook >> ${VSCODE_HOME}/.bashrc

--- a/.devcontainer/updateContent.sh
+++ b/.devcontainer/updateContent.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pixi run -e data setup-data

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.defaultInterpreterPath": "${workspaceFolder}/.pixi/envs/default/bin/python",
+    "python-envs.defaultEnvManager": "ms-python.python:system",
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to Phylo2vec Workshop
+
+To contribute to the Phylo2vec Workshop, you must have [Pixi](https://pixi.sh) installed.
+
+## Setting Up Your Environment
+
+1. **Clone the Repository**: Start by cloning the Phylo2vec Workshop repository to your local machine.
+
+   ```bash
+   git clone https://github.com/sbhattlab/phylo2vec-workshop.git
+   ```
+
+2. **Install Pixi Environment**: Ensure you have the Pixi environment set up. You can do this by running the following command in your terminal:
+
+   ```bash
+   pixi install --all
+   ```
+
+At this point, you should have all the necessary dependencies installed for the Phylo2vec Workshop.
+
+## Contributing to the content
+
+All of the content for the Phylo2vec Workshop is stored in the `docs` directory.
+You can edit the content using your preferred text editor or IDE.
+The technology we use to render the content is [Jupyter Book v2](https://next.jupyterbook.org) and you can add content in the form of [Myst Markdown](https://next.jupyterbook.org/tutorial/mystmd)
+or [Jupyter Notebooks](https://mystmd.org/guide/quickstart-jupyter-lab-myst).
+
+You can preview your changes locally by running the following command in the root of the repository:
+
+```bash
+pixi run -e site start
+```
+
+This will start a local jupyterbook server, and you can view the workshop at the url given in the terminal output, typically `http://localhost:3000`.
+*This server will automatically reload when you make changes to the content*.
+
+After you are satisfied with your changes, you can commit them,
+and then create a pull request to the `main` branch of the repository.
+This will allow [ReadtheDocs](https://readthedocs.org) to generate a preview of your changes.
+
+## Release Process
+
+The release process for the Phylo2vec Workshop is a manual process that involves the following steps.
+
+### 1. Updating the codebase
+
+**NOTE: The release versioning follows the format `YYYY.M.D`, where `YYYY` is the year, `M` is the month, and `D` is the day of the release.**
+
+0. **Create a Release Branch**: Create a new branch for the release, typically named `release/YYYY.M.D`.
+
+1. **Update the Version**: Update the version in `pixi.toml` to reflect the new release version.
+
+2. **Update the Release Notes**: Update the `RELEASE.md` file with the new release date and any relevant changes or updates to the workshop content.
+
+3. **Commit Your Changes**: Commit your changes to the repository with a meaningful commit message, such as "Release version YYYY.M.D".
+
+4. **Make a pull request**: Push your changes to the remote repository and create a pull request to merge your changes into the `main` branch.
+
+### 2. Updating the data and create a release
+
+1. **Setup Github Token**: Ensure you have a GitHub token set up in your environment for release.
+If you don't have a token yet, you can follow the [instruction provided by Github](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).
+Once you have your token, you need to set it in your environment:
+
+   ```bash
+   export GH_TOKEN=your_github_token
+   ```
+
+   Replace `your_github_token` with your actual GitHub token.
+
+2. **Zip and Release the Data**: Run the following command to zip and release the data directory:
+
+   ```bash
+   pixi run -e data release
+   ```
+
+   This will create a `data.zip` file in a `./dist` directory. After that, the script will upload the `data.zip` file to the GitHub release.
+
+### Optional: Updating the data once released
+
+You have the option to update the data after it has been released.
+To do this, you can run the following command:
+
+```bash
+pixi run -e data update-release-data
+```
+
+This command will update the data in the existing release without creating a new release by zipping the `data` directory with the latest data and uploading it to the existing GitHub release.
+
+## Delete a Release (Optional)
+
+If you need to delete a release for any reason, you can do so by running the following command:
+
+```bash
+pixi run -e data delete-release
+```

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,8 @@
+#                             VVVVVV  minimum `pixi` version
+"$schema" = "https://pixi.sh/v0.50.0/schema/manifest/schema.json"
+
 [workspace]
+requires-pixi = ">=0.50,<1.0"
 authors = ["Neil Scheidwasser"]
 channels = ["conda-forge"]
 name = "phylo2vec-workshop"


### PR DESCRIPTION
This pull request sets up a full development environment for the Phylo2vec Workshop using Pixi and Dev Containers, along with documentation and configuration updates to streamline onboarding and contribution. The main themes are environment setup, developer tooling integration, and documentation improvements.

**Development Environment Setup:**

* Added `.devcontainer/Dockerfile` to define a containerized development environment using Ubuntu Jammy and installs Pixi for reproducible package management.
* Created `.devcontainer/devcontainer.json` to configure VSCode Dev Container features, extensions (Jupyter, Python, Ruff, TOML, Pixi), workspace mounts, and resource requirements.
* Added shell scripts `.devcontainer/onCreate.sh` and `.devcontainer/updateContent.sh` for initializing Pixi environments and data setup within the container. [[1]](diffhunk://#diff-6b8b53311bd46db30ff342dedf5a2766cbe34e321b1d91345ef914f2bc6ee829R1-R8) [[2]](diffhunk://#diff-2e316b7ac9baa8f5119add9d6f69529d84b6226d0d8fc355184f55ccb8218ee0R1-R3)

**Tooling and Configuration:**

* Updated `.vscode/settings.json` to ensure Python uses the Pixi-managed interpreter and sets the environment manager to system.
* Updated `pixi.toml` to specify a minimum Pixi version and workspace requirements for consistency across environments.

**Documentation Improvements:**

* Added a comprehensive `CONTRIBUTING.md` detailing environment setup, content contribution workflow, release process, and data management using Pixi commands.