### PR TITLE
feat: Add Read the Docs configuration for project documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+   os: ubuntu-24.04
+   tools:
+      python: "3.13"
+   jobs:
+      create_environment:
+         - asdf plugin add pixi
+         - asdf install pixi latest
+         - asdf global pixi latest
+      install:
+         - pixi install -e site
+      build:
+         html:
+            - NO_COLOR=1 pixi run -e site publish


### PR DESCRIPTION
This pull request updates the documentation build configuration to use modern tooling and a newer operating system. The most important changes are grouped below:

Documentation build system modernization:

* Added a new `.readthedocs.yaml` configuration file with version 2 format to enable Read the Docs builds.
* Updated the build environment to use `ubuntu-24.04` and Python 3.13 for improved compatibility and performance.
* Integrated the `pixi` tool via `asdf` for environment management and building documentation, replacing previous methods.
* Defined explicit build steps for environment creation, installation, and HTML publishing using `pixi`.