### PR TITLE
docs: Update authors list for site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,50 @@
 # Phylo2Vec Workshop
 
-This repository contains materials for the Phylo2Vec Workshop.
+## Abstract
 
-More content coming soon!
+[UPDATE THIS SECTION WITH ACTUAL ABSTRACT]
+
+## Learning Goals
+
+[UPDATE THIS SECTION WITH ACTUAL LEARNING OBJECTIVES]
+
+## Workshop Logistical Information
+
+* Date: 19 September 2025
+* Time: 9:00 AM - 5:00 PM
+* Location: Imperial College London, London, UK
+
+## Preliminary Agenda
+
+**Note:** Subject to change
+
+| Time      | Topic/Activity       |
+|-----------|-----------------------------|
+| 09:00-09:30 | Welcome and Introductions |
+| 09:30-10:30 | Overview of Phylo2Vec and its Applications |
+
+[UPDATE THIS SECTION WITH ACTUAL AGENDA]
+
+## List of Exercises
+
+[UPDATE THIS SECTION WITH ACTUAL EXERCISE NAMES AND DESCRIPTIONS]
+
+## Running the Exercises
+
+The quickest way to get started without manual installation is to use
+[GitHub Codespaces](https://github.com/features/codespaces) - "a development environment that's hosted in the cloud". This allows you to run the workshop exercises directly in your browser without needing to set up a local environment.
+In order to access the Codespace, you need to register an account with [GitHub](https://github.com).
+
+:::{important}
+When clicking the button below, if you have any current codespace,
+we recommend deleting it to ensure you have the latest
+changes from the workshop repository.
+
+Additionally, once codespace is rendered,
+please wait until the `README.md` file is loaded
+to ensure that setup is complete.
+:::
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sbhattlab/phylo2vec-workshop?quickstart=1)
+
+☝️ Click the button above to go to options window to launch a GitHub Codespace.

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -5,8 +5,23 @@ project:
   # title:
   # description:
   # keywords: []
-  # authors: []
+  authors:
+  - name: "Neil Scheidwasser"
+    id: Neclow
+    orcid: "0000-0001-9922-0289"
+    github: Neclow
+  - name: "Landung 'Don' Setiawan"
+    id: lsetiawan
+    affiliations:
+      - id: uw-escience
+        institution: University of Washington
+        department: eScience Institute, Scientific Software Engineering Center
+        ror: 00cvxb145
+    orcid: "0000-0002-1624-2667"
+    github: lsetiawan
   github: https://github.com/sbhattlab/phylo2vec-workshop
+  toc:
+    - file: index.md
   # To autogenerate a Table of Contents, run "jupyter book init --write-toc"
 site:
   template: book-theme


### PR DESCRIPTION
This pull request updates the workshop documentation to provide a more complete structure and adds author information to the project configuration. The most important changes are grouped below:

Documentation improvements:

* Major expansion of `docs/index.md` to include sections for abstract, learning goals, logistical information, preliminary agenda, exercise list, and instructions for running exercises via GitHub Codespaces, replacing the placeholder content.

Project metadata updates:

* Addition of detailed author information to the `docs/myst.yml` configuration, including names, ORCID IDs, GitHub usernames, and affiliations.
* Inclusion of a table of contents entry for `index.md` in the project configuration.